### PR TITLE
Append thread to body and back to its place, due to positioning

### DIFF
--- a/inlineDisqussions.js
+++ b/inlineDisqussions.js
@@ -229,14 +229,21 @@ var disqus_url;
     // Move the discussion to the right position.
     var css = {};
     if (main === true) {
-      $('#disqus_thread').removeClass("positioned");
+      $('#disqus_thread')
+        .appendTo('.disqus_thread_wrap')
+        .removeClass("positioned");
       css = {
         'position': 'static',
         'width': 'auto'
       };
     }
     else {
-      $('#disqus_thread').addClass("positioned");
+      if (!$(".disqus_thread_wrap").length) {
+        $('#disqus_thread').wrap('<div class="disqus_thread_wrap" />');        
+      }
+      $('#disqus_thread')
+        .appendTo("body")
+        .addClass("positioned");
       css = {
         'position': 'absolute'
       };


### PR DESCRIPTION
Some text containers have relative positioning, so taking the commenting link offset().left does not really work, because the left for comments thread is not 0, but the text container position.
